### PR TITLE
fix: container def invalid

### DIFF
--- a/.github/workflows/terragrunt-apply-base.yml
+++ b/.github/workflows/terragrunt-apply-base.yml
@@ -6,8 +6,8 @@ on:
       - main
     paths:
       - ".github/workflows/terragrunt-apply-base.yml"
-      - "terragrunt/env/base/**"
-      - "terragrunt/env/common/**"
+      - "terragrunt/*/base/**"
+      - "terragrunt/*/common/**"
       - "terragrunt/env/terragrunt.hcl"
 
 env:

--- a/.github/workflows/terragrunt-apply-sso-proxy.yml
+++ b/.github/workflows/terragrunt-apply-sso-proxy.yml
@@ -6,8 +6,8 @@ on:
       - main
     paths:
       - ".github/workflows/terragrunt-apply-sso-proxy.yml"
-      - "terragrunt/env/sso_proxy/**"
-      - "terragrunt/env/common/**"
+      - "terragrunt/*/sso_proxy/**"
+      - "terragrunt/*/common/**"
       - "terragrunt/env/terragrunt.hcl"
 
 env:

--- a/.github/workflows/terragrunt-plan-base.yml
+++ b/.github/workflows/terragrunt-plan-base.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
     paths:
       - ".github/workflows/terragrunt-plan-base.yml"
-      - "terragrunt/env/base/**"
-      - "terragrunt/env/common/**"
+      - "terragrunt/*/base/**"
+      - "terragrunt/*/common/**"
       - "terragrunt/env/terragrunt.hcl"
 
 env:

--- a/.github/workflows/terragrunt-plan-sso-proxy.yml
+++ b/.github/workflows/terragrunt-plan-sso-proxy.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
     paths:
       - ".github/workflows/terragrunt-plan-sso-proxy.yml"
-      - "terragrunt/env/sso_proxy/**"
-      - "terragrunt/env/common/**"
+      - "terragrunt/*/sso_proxy/**"
+      - "terragrunt/*/common/**"
       - "terragrunt/env/terragrunt.hcl"
 
 env:

--- a/terragrunt/aws/sso_proxy/configs/policy.yml
+++ b/terragrunt/aws/sso_proxy/configs/policy.yml
@@ -1,6 +1,0 @@
-- from: https://auth.security.cdssandbox.xyz
-  to: http://auth.794722365809.local:8000
-  allowed_domains:
-    - security.cdssandbox.xyz
-  cors_allow_preflight: true
-  timeout: 30s

--- a/terragrunt/aws/sso_proxy/configs/routes.yml
+++ b/terragrunt/aws/sso_proxy/configs/routes.yml
@@ -1,0 +1,7 @@
+routes:
+  - from: https://auth.security.cdssandbox.xyz
+    to: http://auth.794722365809.local:8000
+    allowed_domains:
+      - security.cdssandbox.xyz
+    cors_allow_preflight: true
+    timeout: 30s

--- a/terragrunt/aws/sso_proxy/container-definitions/pomerium_sso_proxy.json.tmpl
+++ b/terragrunt/aws/sso_proxy/container-definitions/pomerium_sso_proxy.json.tmpl
@@ -4,8 +4,8 @@
     "cpu" : 0,
     "environment" : [
       {
-        "name" : "POLICY",
-        "value" : "${POLICY_FILE}"
+        "name" : "ROUTES",
+        "value" : "${ROUTES_FILE}"
       },
       {
         "name" : "IDP_PROVIDER",

--- a/terragrunt/aws/sso_proxy/container-definitions/pomerium_sso_proxy.json.tmpl
+++ b/terragrunt/aws/sso_proxy/container-definitions/pomerium_sso_proxy.json.tmpl
@@ -1,65 +1,67 @@
-{
-  "name" : "pomerium_sso_proxy",
-  "cpu" : 0,
-  "environment" : [
-    {
-      "name" : "POLICY",
-      "value" : "${POLICY_FILE}"
+[
+  {
+    "name" : "pomerium_sso_proxy",
+    "cpu" : 0,
+    "environment" : [
+      {
+        "name" : "POLICY",
+        "value" : "${POLICY_FILE}"
+      },
+      {
+        "name" : "IDP_PROVIDER",
+        "value" : "google"
+      },
+      {
+        "name" : "AUTHENTICATE_SERVICE_URL",
+        "value" : "${AUTHENTICATE_SERVICE_URL}"
+      },
+      {
+        "name" : "AUTOCERT",
+        "value" : "FALSE"
+      },
+      {
+        "name" : "INSECURE_SERVER",
+        "value" : "true"
+      },
+      {
+        "name" : "LOG_LEVEL",
+        "value" : "debug"
+      },
+    ],
+    "essential" : true,
+    "image" : "${POMERIUM_IMAGE}",
+    "logConfiguration" : {
+      "logDriver" : "awslogs",
+      "options" : {
+          "awslogs-group": "${AWS_LOGS_GROUP}",
+          "awslogs-region": "${AWS_LOGS_REGION}",
+          "awslogs-stream-prefix": "${AWS_LOGS_STREAM_PREFIX}"
+      }
     },
-    {
-      "name" : "IDP_PROVIDER",
-      "value" : "google"
-    },
-    {
-      "name" : "AUTHENTICATE_SERVICE_URL",
-      "value" : "${AUTHENTICATE_SERVICE_URL}"
-    },
-    {
-      "name" : "AUTOCERT",
-      "value" : "FALSE"
-    },
-    {
-      "name" : "INSECURE_SERVER",
-      "value" : "true"
-    },
-    {
-      "name" : "LOG_LEVEL",
-      "value" : "debug"
-    },
-  ],
-  "essential" : true,
-  "image" : "${POMERIUM_IMAGE}",
-  "logConfiguration" : {
-    "logDriver" : "awslogs",
-    "options" : {
-        "awslogs-group": "${AWS_LOGS_GROUP}",
-        "awslogs-region": "${AWS_LOGS_REGION}",
-        "awslogs-stream-prefix": "${AWS_LOGS_STREAM_PREFIX}"
-    }
-  },
-  "portMappings" : [
-    {
-      "hostPort" : 443,
-      "ContainerPort" : 443,
-      "Protocol" : "tcp"
-    }
-  ],
-  "secrets" : [
-    {
-      "name" : "SHARED_SECRET",
-      "valueFrom" : "${POMERIUM_CLIENT_ID}"
-    },
-    {
-      "name" : "COOKIE_SECRET",
-      "valueFrom" : "${POMERIUM_CLIENT_SECRET}"
-    },
-    {
-      "name" : "IDP_CLIENT_ID",
-      "valueFrom" : "${POMERIUM_GOOGLE_CLIENT_ID}"
-    },
-    {
-      "name" : "IDP_CLIENT_SECRET",
-      "valueFrom" : "${POMERIUM_GOOGLE_CLIENT_SECRET}"
-    },
-  ],
-}
+    "portMappings" : [
+      {
+        "hostPort" : 443,
+        "ContainerPort" : 443,
+        "Protocol" : "tcp"
+      }
+    ],
+    "secrets" : [
+      {
+        "name" : "SHARED_SECRET",
+        "valueFrom" : "${POMERIUM_CLIENT_ID}"
+      },
+      {
+        "name" : "COOKIE_SECRET",
+        "valueFrom" : "${POMERIUM_CLIENT_SECRET}"
+      },
+      {
+        "name" : "IDP_CLIENT_ID",
+        "valueFrom" : "${POMERIUM_GOOGLE_CLIENT_ID}"
+      },
+      {
+        "name" : "IDP_CLIENT_SECRET",
+        "valueFrom" : "${POMERIUM_GOOGLE_CLIENT_SECRET}"
+      },
+    ],
+  }
+]

--- a/terragrunt/aws/sso_proxy/container-definitions/pomerium_sso_proxy.json.tmpl
+++ b/terragrunt/aws/sso_proxy/container-definitions/pomerium_sso_proxy.json.tmpl
@@ -25,7 +25,7 @@
       {
         "name" : "LOG_LEVEL",
         "value" : "debug"
-      },
+      }
     ],
     "essential" : true,
     "image" : "${POMERIUM_IMAGE}",
@@ -60,7 +60,7 @@
       {
         "name" : "IDP_CLIENT_SECRET",
         "valueFrom" : "${POMERIUM_GOOGLE_CLIENT_SECRET}"
-      },
-    ],
+      }
+    ]
   }
 ]

--- a/terragrunt/aws/sso_proxy/container-definitions/pomerium_sso_proxy.json.tmpl
+++ b/terragrunt/aws/sso_proxy/container-definitions/pomerium_sso_proxy.json.tmpl
@@ -1,7 +1,6 @@
 [
   {
     "name" : "pomerium_sso_proxy",
-    "cpu" : 0,
     "environment" : [
       {
         "name" : "ROUTES",

--- a/terragrunt/aws/sso_proxy/container-definitions/pomerium_sso_proxy_auth.json.tmpl
+++ b/terragrunt/aws/sso_proxy/container-definitions/pomerium_sso_proxy_auth.json.tmpl
@@ -9,7 +9,7 @@
       {
         "name" : "LOG_LEVEL",
         "value" : "debug"
-      },
+      }
     ],
     "essential" : true,
     "image" : "${POMERIUM_VERIFY_IMAGE}",
@@ -44,7 +44,7 @@
       {
         "name" : "IDP_CLIENT_SECRET",
         "valueFrom" : "${POMERIUM_GOOGLE_CLIENT_SECRET}"
-      },
-    ],
+      }
+    ]
   }
 ]

--- a/terragrunt/aws/sso_proxy/container-definitions/pomerium_sso_proxy_auth.json.tmpl
+++ b/terragrunt/aws/sso_proxy/container-definitions/pomerium_sso_proxy_auth.json.tmpl
@@ -1,49 +1,51 @@
-{
-  "name" : "pomerium_sso_proxy_auth",
-  "cpu" : 0,
-  "environment" : [
-    {
-      "name" : "IDP_PROVIDER",
-      "value" : "google"
+[  
+  {
+    "name" : "pomerium_sso_proxy_auth",
+    "cpu" : 0,
+    "environment" : [
+      {
+        "name" : "IDP_PROVIDER",
+        "value" : "google"
+      },
+      {
+        "name" : "LOG_LEVEL",
+        "value" : "debug"
+      },
+    ],
+    "essential" : true,
+    "image" : "${POMERIUM_VERIFY_IMAGE}",
+    "logConfiguration" : {
+      "logDriver" : "awslogs",
+      "options" : {
+          "awslogs-group": "${AWS_LOGS_GROUP}",
+          "awslogs-region": "${AWS_LOGS_REGION}",
+          "awslogs-stream-prefix": "${AWS_LOGS_STREAM_PREFIX}"
+      }
     },
-    {
-      "name" : "LOG_LEVEL",
-      "value" : "debug"
-    },
-  ],
-  "essential" : true,
-  "image" : "${POMERIUM_VERIFY_IMAGE}",
-  "logConfiguration" : {
-    "logDriver" : "awslogs",
-    "options" : {
-        "awslogs-group": "${AWS_LOGS_GROUP}",
-        "awslogs-region": "${AWS_LOGS_REGION}",
-        "awslogs-stream-prefix": "${AWS_LOGS_STREAM_PREFIX}"
-    }
-  },
-  "portMappings" : [
-    {
-      "hostPort" : 8000,
-      "ContainerPort" : 8000,
-      "Protocol" : "tcp"
-    }
-  ],
-  "secrets" : [
-    {
-      "name" : "SHARED_SECRET",
-      "valueFrom" : "${POMERIUM_CLIENT_ID}"
-    },
-    {
-      "name" : "COOKIE_SECRET",
-      "valueFrom" : "${POMERIUM_CLIENT_SECRET}"
-    },
-    {
-      "name" : "IDP_CLIENT_ID",
-      "valueFrom" : "${POMERIUM_GOOGLE_CLIENT_ID}"
-    },
-    {
-      "name" : "IDP_CLIENT_SECRET",
-      "valueFrom" : "${POMERIUM_GOOGLE_CLIENT_SECRET}"
-    },
-  ],
-}
+    "portMappings" : [
+      {
+        "hostPort" : 8000,
+        "ContainerPort" : 8000,
+        "Protocol" : "tcp"
+      }
+    ],
+    "secrets" : [
+      {
+        "name" : "SHARED_SECRET",
+        "valueFrom" : "${POMERIUM_CLIENT_ID}"
+      },
+      {
+        "name" : "COOKIE_SECRET",
+        "valueFrom" : "${POMERIUM_CLIENT_SECRET}"
+      },
+      {
+        "name" : "IDP_CLIENT_ID",
+        "valueFrom" : "${POMERIUM_GOOGLE_CLIENT_ID}"
+      },
+      {
+        "name" : "IDP_CLIENT_SECRET",
+        "valueFrom" : "${POMERIUM_GOOGLE_CLIENT_SECRET}"
+      },
+    ],
+  }
+]

--- a/terragrunt/aws/sso_proxy/container-definitions/pomerium_sso_proxy_auth.json.tmpl
+++ b/terragrunt/aws/sso_proxy/container-definitions/pomerium_sso_proxy_auth.json.tmpl
@@ -1,7 +1,6 @@
 [  
   {
     "name" : "pomerium_sso_proxy_auth",
-    "cpu" : 0,
     "environment" : [
       {
         "name" : "IDP_PROVIDER",

--- a/terragrunt/aws/sso_proxy/outputs.tf
+++ b/terragrunt/aws/sso_proxy/outputs.tf
@@ -1,0 +1,8 @@
+output "sso_proxy_vpc_id" {
+  description = "The VPC ID for the SSO Proxy"
+  value       = module.vpc.vpc_id
+}
+output "internal_hosted_zone_id" {
+  description = "The internal hosted zone id"
+  value       = aws_service_discovery_private_dns_namespace.internal.hosted_zone
+}

--- a/terragrunt/aws/sso_proxy/pomerium_sso.tf
+++ b/terragrunt/aws/sso_proxy/pomerium_sso.tf
@@ -1,5 +1,5 @@
 locals {
-  policy_file = "configs/routes.yml"
+  routes_file = "configs/routes.yml"
 }
 
 resource "aws_ecs_cluster" "pomerium_sso_proxy" {

--- a/terragrunt/aws/sso_proxy/pomerium_sso.tf
+++ b/terragrunt/aws/sso_proxy/pomerium_sso.tf
@@ -1,5 +1,5 @@
 locals {
-  policy_file = "configs/policy.yml"
+  policy_file = "configs/routes.yml"
 }
 
 resource "aws_ecs_cluster" "pomerium_sso_proxy" {
@@ -51,7 +51,7 @@ data "template_file" "pomerium_sso_proxy_container_definition" {
     AWS_LOGS_GROUP                = aws_cloudwatch_log_group.pomerium_sso_proxy.name
     AWS_LOGS_REGION               = var.region
     AWS_LOGS_STREAM_PREFIX        = "${aws_ecs_cluster.pomerium_sso_proxy.name}-task"
-    POLICY_FILE                   = base64encode(file(local.policy_file))
+    ROUTES_FILE                   = base64encode(file(local.routes_file))
     POMERIUM_CLIENT_ID            = aws_ssm_parameter.pomerium_client_id.arn
     POMERIUM_CLIENT_SECRET        = aws_ssm_parameter.pomerium_client_secret.arn
     POMERIUM_GOOGLE_CLIENT_ID     = aws_ssm_parameter.pomerium_google_client_id.arn

--- a/terragrunt/aws/sso_proxy/vpc.tf
+++ b/terragrunt/aws/sso_proxy/vpc.tf
@@ -2,9 +2,9 @@ module "vpc" {
   source = "github.com/cds-snc/terraform-modules?ref=v2.0.2//vpc"
   name   = var.product_name
 
-  cidr            = "172.16.0.0/16"
-  public_subnets  = ["172.16.0.0/20", "172.16.16.0/20", "172.16.32.0/20"]
-  private_subnets = ["172.16.128.0/20", "172.16.144.0/20", "172.16.160.0/20"]
+  cidr            = "172.16.0.0/25"
+  public_subnets  = ["172.16.0.0/28", "172.16.0.16/28", "172.16.0.32/28"]
+  private_subnets = ["172.16.0.64/28", "172.16.0.80/28", "172.16.0.96/28"]
 
 
   high_availability = true


### PR DESCRIPTION
- Missing [] around the container definition
- Reduced vpc subnet ranges so there's a low chance of overlapping with vpc peers in the future
- Switch policy config to routes since pomerium plans to deprecate the `POLICY` env