### PR TITLE
feat: reduce session lifetime to 8 hours

### DIFF
--- a/terragrunt/aws/sso_proxy/container-definitions/pomerium_sso_proxy.json.tmpl
+++ b/terragrunt/aws/sso_proxy/container-definitions/pomerium_sso_proxy.json.tmpl
@@ -3,14 +3,6 @@
     "name" : "pomerium_sso_proxy",
     "environment" : [
       {
-        "name" : "ROUTES",
-        "value" : "${ROUTES_FILE}"
-      },
-      {
-        "name" : "IDP_PROVIDER",
-        "value" : "google"
-      },
-      {
         "name" : "AUTHENTICATE_SERVICE_URL",
         "value" : "${AUTHENTICATE_SERVICE_URL}"
       },
@@ -19,12 +11,24 @@
         "value" : "FALSE"
       },
       {
+        "name" : "COOKIE_EXPIRE",
+        "value" : "${COOKIE_EXPIRE}"
+      },
+      {
+        "name" : "IDP_PROVIDER",
+        "value" : "google"
+      },
+      {
         "name" : "INSECURE_SERVER",
         "value" : "true"
       },
       {
         "name" : "LOG_LEVEL",
         "value" : "debug"
+      },
+      {
+        "name" : "ROUTES",
+        "value" : "${ROUTES_FILE}"
       }
     ],
     "essential" : true,

--- a/terragrunt/aws/sso_proxy/inputs.tf
+++ b/terragrunt/aws/sso_proxy/inputs.tf
@@ -42,6 +42,11 @@ variable "pomerium_verify_image_tag" {
   type        = string
 }
 
+variable "session_cookie_expires_in" {
+  description = "The duration the pomerium session cookie should last"
+  type        = string
+}
+
 variable "session_cookie_secret" {
   description = "The pomerium seed string for secure cookies"
   type        = string

--- a/terragrunt/aws/sso_proxy/pomerium_sso.tf
+++ b/terragrunt/aws/sso_proxy/pomerium_sso.tf
@@ -51,6 +51,7 @@ data "template_file" "pomerium_sso_proxy_container_definition" {
     AWS_LOGS_GROUP                = aws_cloudwatch_log_group.pomerium_sso_proxy.name
     AWS_LOGS_REGION               = var.region
     AWS_LOGS_STREAM_PREFIX        = "${aws_ecs_cluster.pomerium_sso_proxy.name}-task"
+    COOKIE_EXPIRE                 = var.session_cookie_expires_in
     ROUTES_FILE                   = base64encode(file(local.routes_file))
     POMERIUM_CLIENT_ID            = aws_ssm_parameter.pomerium_client_id.arn
     POMERIUM_CLIENT_SECRET        = aws_ssm_parameter.pomerium_client_secret.arn

--- a/terragrunt/env/sso_proxy/terragrunt.hcl
+++ b/terragrunt/env/sso_proxy/terragrunt.hcl
@@ -7,6 +7,7 @@ inputs = {
   pomerium_image_tag        = "git-74310b3d"
   pomerium_verify_image     = "pomerium/verify"
   pomerium_verify_image_tag = "sha-6b38dd5"
+  session_cookie_expires_in = "8h"
 }
 
 include {


### PR DESCRIPTION
By default the SSO proxy session will expire in 14 hours. This is being reduced to 8 hours to align with a full working day instead.