### PR TITLE
fix: use correct oidc role name

### DIFF
--- a/.github/workflows/base-terragrunt-apply.yml
+++ b/.github/workflows/base-terragrunt-apply.yml
@@ -50,7 +50,7 @@ jobs:
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::794722365809:role/gh_admin_role
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/gh_admin_role
           role-session-name: TFApply
           aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/base-terragrunt-plan.yml
+++ b/.github/workflows/base-terragrunt-plan.yml
@@ -49,7 +49,7 @@ jobs:
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::794722365809:role/gh_plan_role
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/gh_plan_role
           role-session-name: TFPlan
           aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -50,7 +50,7 @@ jobs:
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::794722365809:role/gh_admin_role
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/gh_admin_role
           role-session-name: ECRPush
           aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/ci_build_containers.yml
+++ b/.github/workflows/ci_build_containers.yml
@@ -49,7 +49,7 @@ jobs:
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::794722365809:role/gh_admin_role
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/gh_plan_role
           role-session-name: ECRTestLogin
           aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/cloud-asset-inventory-terragrunt-apply.yml
+++ b/.github/workflows/cloud-asset-inventory-terragrunt-apply.yml
@@ -50,7 +50,7 @@ jobs:
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::794722365809:role/gh_admin_role
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/gh_admin_role
           role-session-name: TFApply
           aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/cloud-asset-inventory-terragrunt-plan.yml
+++ b/.github/workflows/cloud-asset-inventory-terragrunt-plan.yml
@@ -49,7 +49,7 @@ jobs:
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::794722365809:role/gh_plan_role
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/gh_plan_role
           role-session-name: TFPlan
           aws-region: ${{ env.AWS_REGION }}
       - name: Get current date to determine if secrets need to be rotated

--- a/.github/workflows/sso-proxy-terragrunt-apply.yml
+++ b/.github/workflows/sso-proxy-terragrunt-apply.yml
@@ -57,7 +57,7 @@ jobs:
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::794722365809:role/gh_admin_role
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/gh_admin_role
           role-session-name: TFApply
           aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/sso-proxy-terragrunt-plan.yml
+++ b/.github/workflows/sso-proxy-terragrunt-plan.yml
@@ -56,7 +56,7 @@ jobs:
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::794722365809:role/gh_plan_role
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/gh_plan_role
           role-session-name: TFPlan
           aws-region: ${{ env.AWS_REGION }}
 

--- a/images/cloud_asset_inventory/cartography/README.md
+++ b/images/cloud_asset_inventory/cartography/README.md
@@ -1,1 +1,1 @@
-Scan all CDS assets; 2022-04-27;9:28 AM
+Scan all CDS assets; 2022-04-27;10:08 AM

--- a/images/cloud_asset_inventory/cartography/README.md
+++ b/images/cloud_asset_inventory/cartography/README.md
@@ -1,1 +1,1 @@
-Scan all CDS assets; 2022-04-26;4:26 PM
+Scan all CDS assets; 2022-04-27;9:28 AM

--- a/images/cloud_asset_inventory/neo4j_ingestor/README.md
+++ b/images/cloud_asset_inventory/neo4j_ingestor/README.md
@@ -1,1 +1,1 @@
-Copied from https://www.marcolancini.it/2020/blog-tracking-moving-clouds-with-cartography/ ; 2022-04-26;4:26 PM
+Copied from https://www.marcolancini.it/2020/blog-tracking-moving-clouds-with-cartography/ ; 2022-04-27;9:28 AM

--- a/images/cloud_asset_inventory/neo4j_ingestor/README.md
+++ b/images/cloud_asset_inventory/neo4j_ingestor/README.md
@@ -1,1 +1,1 @@
-Copied from https://www.marcolancini.it/2020/blog-tracking-moving-clouds-with-cartography/ ; 2022-04-27;9:28 AM
+Copied from https://www.marcolancini.it/2020/blog-tracking-moving-clouds-with-cartography/ ; 2022-04-27;10:08 AM


### PR DESCRIPTION
The wrong OIDC name was being used for the ci login test step. Account id references also updated to reference a single source so that it's more portable.

Path filter also blocked the previous PR from deploying the images since nothing in the images folder contained a change. This PR commits an artificial change so that the 2 images are deployed to ECR.