### PR TITLE
fix: remove trailing comma

### DIFF
--- a/terragrunt/aws/cloud_asset_inventory/container-definitions/cartography.json.tmpl
+++ b/terragrunt/aws/cloud_asset_inventory/container-definitions/cartography.json.tmpl
@@ -14,7 +14,7 @@
         {
           "name" : "NEO4J_USER",
           "value" : "neo4j"
-        },
+        }
       ],
       "essential" : true,
       "image" : "${CARTOGRAPHY_IMAGE}",
@@ -38,6 +38,6 @@
           "name" : "NEO4J_SECRETS_PASSWORD",
           "valueFrom" : "${NEO4J_SECRETS_PASSWORD}"
         }
-      ],
-    },
+      ]
+    }
   ]


### PR DESCRIPTION
Trailing comma's aren't permitted in ECS container definitions.