### PR TITLE
fix: use unique names for target groups

### DIFF
--- a/terragrunt/aws/cloud_asset_inventory/lb.tf
+++ b/terragrunt/aws/cloud_asset_inventory/lb.tf
@@ -6,7 +6,7 @@ resource "aws_lb" "cartography" {
   name               = "cartography"
   internal           = true
   load_balancer_type = "network"
-  subnets            = module.vpc.public_subnet_ids
+  subnets            = module.vpc.private_subnet_ids
 
   access_logs {
     bucket  = var.cbs_satellite_bucket_name

--- a/terragrunt/aws/cloud_asset_inventory/lb.tf
+++ b/terragrunt/aws/cloud_asset_inventory/lb.tf
@@ -24,7 +24,7 @@ resource "aws_lb" "cartography" {
   }
 }
 
-resource "aws_lb_target_group" "ecs" {
+resource "aws_lb_target_group" "neo4j" {
   name                 = "ecs"
   port                 = 7474
   protocol             = "TCP"
@@ -63,7 +63,7 @@ resource "aws_lb_listener" "https" {
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.ecs.arn
+    target_group_arn = aws_lb_target_group.neo4j.arn
   }
 
   tags = {

--- a/terragrunt/aws/cloud_asset_inventory/lb.tf
+++ b/terragrunt/aws/cloud_asset_inventory/lb.tf
@@ -4,7 +4,7 @@
 resource "aws_lb" "cartography" {
   #checkov:skip=CKV_AWS_152:Load Balancer: Not running in high availability mode
   name               = "cartography"
-  internal           = false
+  internal           = true
   load_balancer_type = "network"
   subnets            = module.vpc.public_subnet_ids
 

--- a/terragrunt/aws/cloud_asset_inventory/lb.tf
+++ b/terragrunt/aws/cloud_asset_inventory/lb.tf
@@ -55,7 +55,7 @@ resource "aws_lb_target_group" "bolt" {
 }
 
 
-resource "aws_lb_listener" "https" {
+resource "aws_lb_listener" "neo4j" {
   load_balancer_arn = aws_lb.cartography.arn
 
   port     = 7474

--- a/terragrunt/aws/cloud_asset_inventory/neo4j.tf
+++ b/terragrunt/aws/cloud_asset_inventory/neo4j.tf
@@ -22,7 +22,7 @@ resource "aws_ecs_service" "neo4j" {
   health_check_grace_period_seconds = 600
 
   load_balancer {
-    target_group_arn = aws_lb_target_group.ecs.arn
+    target_group_arn = aws_lb_target_group.neo4j.arn
     container_name   = "neo4j"
     container_port   = 7474
   }

--- a/terragrunt/aws/sso_proxy/alb.tf
+++ b/terragrunt/aws/sso_proxy/alb.tf
@@ -25,7 +25,7 @@ resource "aws_lb" "pomerium" {
   }
 }
 
-resource "aws_lb_target_group" "ecs" {
+resource "aws_lb_target_group" "sso_proxy" {
   name                 = "ecs"
   port                 = 443
   protocol             = "HTTP"
@@ -83,7 +83,7 @@ resource "aws_lb_listener" "https" {
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.ecs.arn
+    target_group_arn = aws_lb_target_group.sso_proxy.arn
   }
 
   tags = {

--- a/terragrunt/aws/sso_proxy/pomerium_sso.tf
+++ b/terragrunt/aws/sso_proxy/pomerium_sso.tf
@@ -26,7 +26,7 @@ resource "aws_ecs_service" "pomerium_sso_proxy" {
   health_check_grace_period_seconds = 600
 
   load_balancer {
-    target_group_arn = aws_lb_target_group.ecs.arn
+    target_group_arn = aws_lb_target_group.sso_proxy.arn
     container_name   = "pomerium_sso_proxy"
     container_port   = 443
   }


### PR DESCRIPTION
Apply failing due to duplicate load balancer target group names

![image](https://user-images.githubusercontent.com/85885638/165631578-18fa2854-efe0-42a6-bff0-d92d571af868.png)
