### PR TITLE
fix: use correct syntax for pulling specific image using sha

### DIFF
--- a/terragrunt/aws/cloud_asset_inventory/neo4j.tf
+++ b/terragrunt/aws/cloud_asset_inventory/neo4j.tf
@@ -56,7 +56,7 @@ data "template_file" "neo4j_container_definition" {
     AWS_LOGS_GROUP         = aws_cloudwatch_log_group.neo4j.name
     AWS_LOGS_REGION        = var.region
     AWS_LOGS_STREAM_PREFIX = "${aws_ecs_cluster.neo4j.name}-task"
-    NEO4J_IMAGE            = "${var.neo4j_image}:${var.neo4j_image_tag}"
+    NEO4J_IMAGE            = "${var.neo4j_image}@${var.neo4j_image_tag}"
     NEO4J_AUTH             = aws_ssm_parameter.neo4j_auth.arn
   }
 }

--- a/terragrunt/aws/cloud_asset_inventory/neo4j.tf
+++ b/terragrunt/aws/cloud_asset_inventory/neo4j.tf
@@ -56,7 +56,7 @@ data "template_file" "neo4j_container_definition" {
     AWS_LOGS_GROUP         = aws_cloudwatch_log_group.neo4j.name
     AWS_LOGS_REGION        = var.region
     AWS_LOGS_STREAM_PREFIX = "${aws_ecs_cluster.neo4j.name}-task"
-    NEO4J_IMAGE            = "${var.neo4j_image}@${var.neo4j_image_tag}"
+    NEO4J_IMAGE            = "${var.neo4j_image}:${var.neo4j_image_tag}"
     NEO4J_AUTH             = aws_ssm_parameter.neo4j_auth.arn
   }
 }

--- a/terragrunt/env/cloud_asset_inventory/terragrunt.hcl
+++ b/terragrunt/env/cloud_asset_inventory/terragrunt.hcl
@@ -20,7 +20,7 @@ inputs = {
   asset_inventory_managed_accounts = split("\n", chomp(replace(file("configs/accounts.txt"), "\"", "")))
   cartography_repository_url       = dependency.base.outputs.cartography_repository_url
   neo4j_image                      = "neo4j"
-  neo4j_image_tag                  = "sha256:aabe1e6e19a8582d7fd9a42f7317b0e260e7870ce3e6b4dacffb2f7d6d141a31"
+  neo4j_image_tag                  = "4.4@sha256:aabe1e6e19a8582d7fd9a42f7317b0e260e7870ce3e6b4dacffb2f7d6d141a31"
 }
 
 include {


### PR DESCRIPTION
ECS is unable to pull the docker image using the sha256 due to a syntax error