### PR TITLE
feat: allow egress to peered vpc cidr

### DIFF
--- a/terragrunt/aws/sso_proxy/configs/routes.yml.tmpl
+++ b/terragrunt/aws/sso_proxy/configs/routes.yml.tmpl
@@ -16,3 +16,12 @@
           or:
             - domain:
                 is: cds-snc.ca
+
+- from: https://bolt.neo4j.security.cdssandbox.xyz
+  to: http://${CLOUD_ASSET_INVENTORY_LOAD_BALANCER_DNS}:7687/
+  preserve_host_header: true
+  policy:
+      - allow:
+          or:
+            - domain:
+                is: cds-snc.ca

--- a/terragrunt/aws/sso_proxy/configs/routes.yml.tmpl
+++ b/terragrunt/aws/sso_proxy/configs/routes.yml.tmpl
@@ -9,7 +9,8 @@
   timeout: 30s
 
 - from: https://neo4j.security.cdssandbox.xyz
-  to: https://${CLOUD_ASSET_INVENTORY_LOAD_BALANCER_DNS}:7474
+  to: http://${CLOUD_ASSET_INVENTORY_LOAD_BALANCER_DNS}:7474/
+  preserve_host_header: true
   policy:
       - allow:
           or:

--- a/terragrunt/aws/sso_proxy/vpc.tf
+++ b/terragrunt/aws/sso_proxy/vpc.tf
@@ -30,6 +30,13 @@ resource "aws_security_group" "pomerium" {
   description = "Allow inbound traffic to pomerium load balancer"
   vpc_id      = module.vpc.vpc_id
 
+  egress {
+    description = "Access Cartography cidr"
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "tcp"
+    cidr_blocks = [var.cloud_asset_inventory_cidr]
+  }
 
   egress {
     description = "Access to the internet"


### PR DESCRIPTION
Allow unrestricted access between the two peered VPC's. Security group rules will enforce network rules. Also enabling the proxies `preserve_host_header` setting since Neo4j isn't respecting the X-Forwarded-* header.

Note: currently the private subnets communicate via http but will be upgraded to https at later date once i figure out how to get neo4j to use a aws issued cert.