### PR TITLE
fix: elasticsearch user is mandatory

### DIFF
--- a/terragrunt/aws/cloud_asset_inventory/elasticsearch.tf
+++ b/terragrunt/aws/cloud_asset_inventory/elasticsearch.tf
@@ -16,7 +16,12 @@ resource "aws_elasticsearch_domain" "cartography" {
   }
 
   advanced_security_options {
-    enabled = true
+    enabled                        = true
+    internal_user_database_enabled = true
+    master_user_options {
+      master_user_name     = aws_ssm_parameter.elasticsearch_user.value
+      master_user_password = aws_ssm_parameter.elasticsearch_password.value
+    }
   }
 
   cluster_config {


### PR DESCRIPTION
Was hoping to use sso proxy to control access but it seems that elasticsearch requires a user