### PR TITLE
fix: meet elasticsearch password complexity requirements

### DIFF
--- a/terragrunt/aws/cloud_asset_inventory/ssm.tf
+++ b/terragrunt/aws/cloud_asset_inventory/ssm.tf
@@ -3,7 +3,14 @@
 resource "random_password" "elasticsearch_password" {
   for_each = toset([var.password_change_id])
   length   = 32
-  special  = false
+  lower    = true
+  upper    = true
+  special  = true
+
+  min_lower   = 1
+  min_upper   = 1
+  min_numeric = 1
+  min_special = 1
 }
 
 resource "random_password" "neo4j_password" {


### PR DESCRIPTION
Elasticsearch password has specific requirements. This PR updates the dynamic password generation so that rotated passwords always meet the requirements.

![image](https://user-images.githubusercontent.com/85885638/165992992-851ebabc-9010-4eee-a200-25649e7c4499.png)
