### PR TITLE
refactor: group clusters, fix event iam, create efs

### DIFF
--- a/images/cloud_asset_inventory/cartography/Dockerfile
+++ b/images/cloud_asset_inventory/cartography/Dockerfile
@@ -6,6 +6,10 @@ RUN apk add jq curl
 RUN mkdir -p /config
 WORKDIR /config
 
+COPY --chown=python:python docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
+RUN chown -R python:python /config
+
 USER python
 RUN /usr/local/bin/python -m venv /home/python/venv
 ENV PATH="/home/python/venv/bin:${PATH}" \
@@ -13,11 +17,5 @@ ENV PATH="/home/python/venv/bin:${PATH}" \
 
 COPY --chown=python:python requirements.txt /home/python/cartography/requirements.txt
 RUN /home/python/venv/bin/pip install --no-cache-dir --requirement /home/python/cartography/requirements.txt
-
-USER root
-COPY --chown=python:python docker-entrypoint.sh /
-RUN chmod +x /docker-entrypoint.sh
-RUN chown -R python:python /config
-USER python
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/images/cloud_asset_inventory/cartography/Dockerfile
+++ b/images/cloud_asset_inventory/cartography/Dockerfile
@@ -4,7 +4,6 @@ RUN /usr/sbin/adduser -g python -D python
 RUN apk add jq curl
 
 RUN mkdir -p /config
-VOLUME /config
 WORKDIR /config
 
 USER python

--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -4,5 +4,6 @@ skip-check:
   - CKV_AWS_116 # Lambda: Dead Letter Queue not required
   - CKV_AWS_158 # CloudWatch: default AWS Managed encryption key is acceptable
   - CKV_AWS_173 # Lambda: environment variable encryption with default KMS key is acceptable
+  - CKV_AWS_184 # EFS: default AWS Managed encryption key is acceptable
   - CKV_AWS_231 # port 3389 blocked by the vpc terraform module using the block_rdp flag
   - CKV_AWS_241 # Kinesis firehose: default AWS Managed encryption key is acceptable

--- a/terragrunt/aws/cloud_asset_inventory/cartography.tf
+++ b/terragrunt/aws/cloud_asset_inventory/cartography.tf
@@ -1,16 +1,5 @@
-resource "aws_ecs_cluster" "cartography" {
-  name = "cartography"
-
-  setting {
-    name  = "containerInsights"
-    value = "enabled"
-  }
-
-  tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-    Terraform             = true
-    Product               = var.product_name
-  }
+locals {
+  cartography_service_name = "cartography"
 }
 
 data "template_file" "cartography_container_definition" {
@@ -19,14 +8,14 @@ data "template_file" "cartography_container_definition" {
   vars = {
     AWS_LOGS_GROUP         = aws_cloudwatch_log_group.cartography.name
     AWS_LOGS_REGION        = var.region
-    AWS_LOGS_STREAM_PREFIX = "${aws_ecs_cluster.cartography.name}-task"
+    AWS_LOGS_STREAM_PREFIX = "${local.cartography_service_name}-task"
     CARTOGRAPHY_IMAGE      = "${var.cartography_repository_url}:latest"
     NEO4J_SECRETS_PASSWORD = aws_ssm_parameter.neo4j_password.arn
   }
 }
 
 resource "aws_ecs_task_definition" "cartography" {
-  family                   = "cartography"
+  family                   = local.cartography_service_name
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
 
@@ -46,7 +35,7 @@ resource "aws_ecs_task_definition" "cartography" {
 }
 
 resource "aws_cloudwatch_log_group" "cartography" {
-  name              = "/aws/ecs/cartography"
+  name              = "/aws/ecs/${local.cartography_service_name}"
   retention_in_days = 14
 
   tags = {

--- a/terragrunt/aws/cloud_asset_inventory/cartography.tf
+++ b/terragrunt/aws/cloud_asset_inventory/cartography.tf
@@ -6,11 +6,12 @@ data "template_file" "cartography_container_definition" {
   template = file("container-definitions/cartography.json.tmpl")
 
   vars = {
-    AWS_LOGS_GROUP         = aws_cloudwatch_log_group.cartography.name
-    AWS_LOGS_REGION        = var.region
-    AWS_LOGS_STREAM_PREFIX = "${local.cartography_service_name}-task"
-    CARTOGRAPHY_IMAGE      = "${var.cartography_repository_url}:latest"
-    NEO4J_SECRETS_PASSWORD = aws_ssm_parameter.neo4j_password.arn
+    AWS_LOGS_GROUP           = aws_cloudwatch_log_group.cartography.name
+    AWS_LOGS_REGION          = var.region
+    AWS_LOGS_STREAM_PREFIX   = "${local.cartography_service_name}-task"
+    CARTOGRAPHY_IMAGE        = "${var.cartography_repository_url}:latest"
+    CARTOGRAPHY_SERVICE_NAME = local.cartography_service_name
+    NEO4J_SECRETS_PASSWORD   = aws_ssm_parameter.neo4j_password.arn
   }
 }
 

--- a/terragrunt/aws/cloud_asset_inventory/container-definitions/cartography.json.tmpl
+++ b/terragrunt/aws/cloud_asset_inventory/container-definitions/cartography.json.tmpl
@@ -1,6 +1,6 @@
 [
   {
-    "name" : "cartography",
+    "name" : "${CARTOGRAPHY_SERVICE_NAME}",
     "environment" : [
       {
         "name" : "AWS_CONFIG_FILE",

--- a/terragrunt/aws/cloud_asset_inventory/container-definitions/neo4j.json.tmpl
+++ b/terragrunt/aws/cloud_asset_inventory/container-definitions/neo4j.json.tmpl
@@ -21,6 +21,13 @@
     ],
     "essential" : true,
     "image" : "${NEO4J_IMAGE}",
+    "mountPoints" : [
+      {
+        "sourceVolume" : "${EFS_VOLUME_NAME}",
+        "containerPath" : "/var/lib/neo4j/data",
+        "readOnly" : false
+      }
+    ],
     "logConfiguration" : {
       "logDriver" : "awslogs",
       "options" : {

--- a/terragrunt/aws/cloud_asset_inventory/ecs.tf
+++ b/terragrunt/aws/cloud_asset_inventory/ecs.tf
@@ -1,0 +1,14 @@
+resource "aws_ecs_cluster" "cloud_asset_discovery" {
+  name = "cloud_asset_discovery"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+    Product               = var.product_name
+  }
+}

--- a/terragrunt/aws/cloud_asset_inventory/efs.tf
+++ b/terragrunt/aws/cloud_asset_inventory/efs.tf
@@ -1,4 +1,6 @@
 resource "aws_efs_file_system" "neo4j" {
+  encrypted = true
+
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true

--- a/terragrunt/aws/cloud_asset_inventory/efs.tf
+++ b/terragrunt/aws/cloud_asset_inventory/efs.tf
@@ -1,0 +1,14 @@
+resource "aws_efs_file_system" "neo4j" {
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+    Product               = var.product_name
+  }
+}
+
+resource "aws_efs_mount_target" "neo4j" {
+  count           = length(module.vpc.private_subnet_ids)
+  file_system_id  = aws_efs_file_system.neo4j.id
+  subnet_id       = element(module.vpc.private_subnet_ids, count.index)
+  security_groups = [aws_security_group.cartography.id]
+}

--- a/terragrunt/aws/cloud_asset_inventory/neo4j.tf
+++ b/terragrunt/aws/cloud_asset_inventory/neo4j.tf
@@ -68,7 +68,8 @@ resource "aws_ecs_task_definition" "neo4j" {
   volume {
     name = local.efs_volume_name
     efs_volume_configuration {
-      file_system_id = aws_efs_file_system.neo4j.id
+      file_system_id     = aws_efs_file_system.neo4j.id
+      transit_encryption = "ENABLED"
     }
   }
 

--- a/terragrunt/aws/cloud_asset_inventory/neo4j_ingestor.tf
+++ b/terragrunt/aws/cloud_asset_inventory/neo4j_ingestor.tf
@@ -1,20 +1,6 @@
 locals {
-  elasticsearch_config_file = "configs/es-index.json"
-}
-
-resource "aws_ecs_cluster" "neo4j_ingestor" {
-  name = "neo4j_ingestor"
-
-  setting {
-    name  = "containerInsights"
-    value = "enabled"
-  }
-
-  tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-    Terraform             = true
-    Product               = var.product_name
-  }
+  elasticsearch_config_file   = "configs/es-index.json"
+  neo4j_ingestor_service_name = "neo4j_ingestor"
 }
 
 data "template_file" "neo4j_ingestor_container_definition" {
@@ -23,7 +9,7 @@ data "template_file" "neo4j_ingestor_container_definition" {
   vars = {
     AWS_LOGS_GROUP         = aws_cloudwatch_log_group.neo4j_ingestor.name
     AWS_LOGS_REGION        = var.region
-    AWS_LOGS_STREAM_PREFIX = "${aws_ecs_cluster.neo4j_ingestor.name}-task"
+    AWS_LOGS_STREAM_PREFIX = "${local.neo4j_ingestor_service_name}-task"
     ELASTIC_URL            = "${aws_elasticsearch_domain.cartography.endpoint}:443"
     ENTRYPOINT_COMMAND = join(" ", [
       "set -ueo pipefail; echo ${base64encode(file(local.elasticsearch_config_file))} | base64 -d > /opt/es-index/es-index.json;",
@@ -31,13 +17,15 @@ data "template_file" "neo4j_ingestor_container_definition" {
     ])
     ELASTICSEARCH_USER     = aws_ssm_parameter.elasticsearch_user.arn
     ELASTICSEARCH_PASSWORD = aws_ssm_parameter.elasticsearch_password.arn
+    MIN_ECS_CAPACITY       = var.min_ecs_capacity
+    MAX_ECS_CAPACITY       = var.max_ecs_capacity
     NEO4J_INGESTOR_IMAGE   = "${var.neo4j_ingestor_repository_url}:latest"
     NEO4J_SECRETS_PASSWORD = aws_ssm_parameter.neo4j_password.arn
   }
 }
 
 resource "aws_ecs_task_definition" "neo4j_ingestor" {
-  family                   = "neo4j_ingestor"
+  family                   = local.neo4j_ingestor_service_name
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
 
@@ -61,7 +49,7 @@ resource "aws_ecs_task_definition" "neo4j_ingestor" {
 }
 
 resource "aws_cloudwatch_log_group" "neo4j_ingestor" {
-  name              = "/aws/ecs/neo4j_ingestor"
+  name              = "/aws/ecs/${local.neo4j_ingestor_service_name}"
   retention_in_days = 14
 
   tags = {

--- a/terragrunt/aws/cloud_asset_inventory/ssm.tf
+++ b/terragrunt/aws/cloud_asset_inventory/ssm.tf
@@ -6,7 +6,7 @@ resource "random_password" "elasticsearch_password" {
   lower            = true
   upper            = true
   special          = true
-  override_special = "%*()-_[]{}<>" # Allowed special characters
+  override_special = "%*()-_{}<>" # Allowed special characters that dont overlap with ip address and http RFC's
 
   min_lower   = 1
   min_upper   = 1

--- a/terragrunt/aws/cloud_asset_inventory/state-machines/cartography.json.tmpl
+++ b/terragrunt/aws/cloud_asset_inventory/state-machines/cartography.json.tmpl
@@ -48,7 +48,7 @@
               "Overrides": {
                 "ContainerOverrides": [
                   {
-                    "Name": "${CARTOGRAPHY_CONTAINER_NAME}",
+                    "Name": "${CARTOGRAPHY_SERVICE_NAME}",
                     "Environment": [
                       {
                         "Name": "AWS_ACCOUNT",

--- a/terragrunt/aws/cloud_asset_inventory/state-machines/cartography.json.tmpl
+++ b/terragrunt/aws/cloud_asset_inventory/state-machines/cartography.json.tmpl
@@ -32,6 +32,18 @@
             "Parameters": {
               "LaunchType": "FARGATE",
               "Cluster": "${CARTOGRAPHY_CLUSTER}",
+              "CapacityProviderStrategy": [
+                {
+                  "Base": ${MIN_ECS_CAPACITY},
+                  "CapacityProvider": "FARGATE_SPOT",
+                  "Weight": ${MAX_ECS_CAPACITY}
+                },
+                {
+                  "Base": 0,
+                  "CapacityProvider": "FARGATE",
+                  "Weight": ${MIN_ECS_CAPACITY}
+                }
+              ],
               "TaskDefinition": "${CARTOGRAPHY_TASK_DEF}",
               "Overrides": {
                 "ContainerOverrides": [
@@ -80,6 +92,18 @@
       "Parameters": {
         "LaunchType": "FARGATE",
         "Cluster" : "${NEO4J_INGESTOR_CLUSTER}",
+        "CapacityProviderStrategy": [
+          {
+            "Base": ${MIN_ECS_CAPACITY},
+            "CapacityProvider": "FARGATE_SPOT",
+            "Weight": ${MAX_ECS_CAPACITY}
+          },
+          {
+            "Base": 0,
+            "CapacityProvider": "FARGATE",
+            "Weight": ${MIN_ECS_CAPACITY}
+          }
+        ],
         "TaskDefinition" : "${NEO4J_INGESTOR_TASK_DEF}",
         "NetworkConfiguration": {
           "AwsvpcConfiguration": {

--- a/terragrunt/aws/cloud_asset_inventory/state_machine.tf
+++ b/terragrunt/aws/cloud_asset_inventory/state_machine.tf
@@ -14,10 +14,12 @@ data "template_file" "asset_inventory_cartography_state_machine" {
   template = file("state-machines/cartography.json.tmpl")
 
   vars = {
-    CARTOGRAPHY_CONTAINER_NAME = aws_ecs_cluster.cartography.name
-    CARTOGRAPHY_CLUSTER        = aws_ecs_cluster.cartography.arn
+    CARTOGRAPHY_CONTAINER_NAME = aws_ecs_task_definition.cartography.family
+    CARTOGRAPHY_CLUSTER        = aws_ecs_cluster.cloud_asset_discovery.arn
     CARTOGRAPHY_TASK_DEF       = aws_ecs_task_definition.cartography.arn
-    NEO4J_INGESTOR_CLUSTER     = aws_ecs_cluster.neo4j_ingestor.arn
+    MIN_ECS_CAPACITY           = var.min_ecs_capacity
+    MAX_ECS_CAPACITY           = var.max_ecs_capacity
+    NEO4J_INGESTOR_CLUSTER     = aws_ecs_cluster.cloud_asset_discovery.arn
     NEO4J_INGESTOR_TASK_DEF    = aws_ecs_task_definition.neo4j_ingestor.arn
     SECURITY_GROUPS            = aws_security_group.cartography.id
     SUBNETS                    = join(", ", [for subnet in module.vpc.private_subnet_ids : subnet])
@@ -82,6 +84,16 @@ data "aws_iam_policy_document" "asset_inventory_cartography_state_machine" {
     resources = [
       aws_iam_role.cartography_task_execution_role.arn,
       aws_iam_role.cartography_container_execution_role.arn,
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "states:StartExecution",
+    ]
+    resources = [
+      aws_sfn_state_machine.asset_inventory_cartography.arn,
     ]
   }
 

--- a/terragrunt/aws/cloud_asset_inventory/state_machine.tf
+++ b/terragrunt/aws/cloud_asset_inventory/state_machine.tf
@@ -2,6 +2,12 @@ resource "aws_cloudwatch_event_rule" "asset_inventory_cartography" {
   name                = "cartography"
   schedule_expression = "cron(0 22 * * ? *)"
   is_enabled          = true
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+    Product               = var.product_name
+  }
 }
 
 resource "aws_cloudwatch_event_target" "sfn_events" {
@@ -68,6 +74,12 @@ resource "aws_iam_policy" "asset_inventory_cartography_state_machine" {
   name   = "CartographyStateMachineECSLambda"
   path   = "/"
   policy = data.aws_iam_policy_document.asset_inventory_cartography_state_machine.json
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+    Product               = var.product_name
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "asset_inventory_cartography_state_machine" {

--- a/terragrunt/aws/cloud_asset_inventory/state_machine.tf
+++ b/terragrunt/aws/cloud_asset_inventory/state_machine.tf
@@ -14,15 +14,16 @@ data "template_file" "asset_inventory_cartography_state_machine" {
   template = file("state-machines/cartography.json.tmpl")
 
   vars = {
-    CARTOGRAPHY_CONTAINER_NAME = aws_ecs_task_definition.cartography.family
-    CARTOGRAPHY_CLUSTER        = aws_ecs_cluster.cloud_asset_discovery.arn
-    CARTOGRAPHY_TASK_DEF       = aws_ecs_task_definition.cartography.arn
-    MIN_ECS_CAPACITY           = var.min_ecs_capacity
-    MAX_ECS_CAPACITY           = var.max_ecs_capacity
-    NEO4J_INGESTOR_CLUSTER     = aws_ecs_cluster.cloud_asset_discovery.arn
-    NEO4J_INGESTOR_TASK_DEF    = aws_ecs_task_definition.neo4j_ingestor.arn
-    SECURITY_GROUPS            = aws_security_group.cartography.id
-    SUBNETS                    = join(", ", [for subnet in module.vpc.private_subnet_ids : subnet])
+
+    CARTOGRAPHY_SERVICE_NAME = local.cartography_service_name
+    CARTOGRAPHY_CLUSTER      = aws_ecs_cluster.cloud_asset_discovery.arn
+    CARTOGRAPHY_TASK_DEF     = aws_ecs_task_definition.cartography.arn
+    MIN_ECS_CAPACITY         = var.min_ecs_capacity
+    MAX_ECS_CAPACITY         = var.max_ecs_capacity
+    NEO4J_INGESTOR_CLUSTER   = aws_ecs_cluster.cloud_asset_discovery.arn
+    NEO4J_INGESTOR_TASK_DEF  = aws_ecs_task_definition.neo4j_ingestor.arn
+    SECURITY_GROUPS          = aws_security_group.cartography.id
+    SUBNETS                  = join(", ", [for subnet in module.vpc.private_subnet_ids : subnet])
   }
 }
 

--- a/terragrunt/aws/cloud_asset_inventory/vpc.tf
+++ b/terragrunt/aws/cloud_asset_inventory/vpc.tf
@@ -33,7 +33,15 @@ resource "aws_security_group" "cartography" {
   vpc_id      = module.vpc.vpc_id
 
   ingress {
-    description = "Access to efs"
+    description = "Allow NFS traffic out from ECS to mount target"
+    from_port   = 2049
+    to_port     = 2049
+    protocol    = "tcp"
+    cidr_blocks = module.vpc.private_subnet_cidr_blocks
+  }
+
+  egress {
+    description = "Allow NFS traffic into mount target from ECS"
     from_port   = 2049
     to_port     = 2049
     protocol    = "tcp"

--- a/terragrunt/aws/sso_proxy/ecs.tf
+++ b/terragrunt/aws/sso_proxy/ecs.tf
@@ -1,0 +1,14 @@
+resource "aws_ecs_cluster" "sso_proxy" {
+  name = "sso_proxy"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+    Product               = var.product_name
+  }
+}

--- a/terragrunt/env/common/common_variables.tf
+++ b/terragrunt/env/common/common_variables.tf
@@ -40,6 +40,16 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "min_ecs_capacity" {
+  description = "Minimum number of ECS instances to keep in the cluster"
+  type        = number
+}
+
+variable "max_ecs_capacity" {
+  description = "Maximum number of ECS instances to keep in the cluster"
+  type        = number
+}
+
 ### CIDR ranges for the VPC's in the account
 
 variable "sso_proxy_cidr" {

--- a/terragrunt/env/terragrunt.hcl
+++ b/terragrunt/env/terragrunt.hcl
@@ -1,12 +1,14 @@
 inputs = {
   account_id                 = "${get_aws_account_id()}"
-  domain_name                = "security.cdssandbox.xyz"
-  internal_domain_name       = "${get_aws_account_id()}.local"
-  product_name               = "security-tools"
   billing_tag_key            = "CostCentre"
   billing_tag_value          = "security-tools-${get_aws_account_id()}"
-  region                     = "ca-central-1"
   cbs_satellite_bucket_name  = "cbs-satellite-${get_aws_account_id()}"
+  domain_name                = "security.cdssandbox.xyz"
+  internal_domain_name       = "${get_aws_account_id()}.local"
+  min_ecs_capacity           = 1
+  max_ecs_capacity           = 5
+  product_name               = "security-tools"
+  region                     = "ca-central-1"
   sso_proxy_cidr             = "10.0.0.0/21" # Reserve 2,046 IP addresses for VPC
   cloud_asset_inventory_cidr = "10.0.8.0/22" # Reserve 1,022 IP addresses for VPC
 }


### PR DESCRIPTION
Fixes & refactor:
- Launch asset discovery using `FARGATE SPOT` with `FARGATE` as the fallback
- Remove volume from dockerfile since it's not needed as well as interfering with directory ownership
- IAM permissions so that eventbridge can launch the step function
- Discontinue one cluster per container. Clusters will now be grouped by service
- Create EFS persistent mount so that Neo4J data isn't lost when containers cycle
- Elasticsearch password special character list reduced due to conflicts with pythons urlparse library