### PR TITLE
feat: no longer required to manual auth to bolt service

### DIFF
--- a/terragrunt/aws/sso_proxy/container-definitions/pomerium_sso_proxy.json.tmpl
+++ b/terragrunt/aws/sso_proxy/container-definitions/pomerium_sso_proxy.json.tmpl
@@ -29,6 +29,10 @@
       {
         "name" : "ROUTES",
         "value" : "${ROUTES_FILE}"
+      },
+      {
+        "name" : "COOKIE_DOMAIN",
+        "value" : "${COOKIE_DOMAIN}"
       }
     ],
     "essential" : true,

--- a/terragrunt/aws/sso_proxy/pomerium_sso.tf
+++ b/terragrunt/aws/sso_proxy/pomerium_sso.tf
@@ -45,6 +45,7 @@ data "template_file" "pomerium_sso_proxy_container_definition" {
     AWS_LOGS_GROUP                = aws_cloudwatch_log_group.pomerium_sso_proxy.name
     AWS_LOGS_REGION               = var.region
     AWS_LOGS_STREAM_PREFIX        = "${local.pomerium_sso_proxy_service_name}-task"
+    COOKIE_DOMAIN                 = var.domain_name
     COOKIE_EXPIRE                 = var.session_cookie_expires_in
     ROUTES_FILE                   = base64encode(data.template_file.pomerium_sso_proxy_routes_policy.rendered)
     POMERIUM_CLIENT_ID            = aws_ssm_parameter.pomerium_client_id.arn


### PR DESCRIPTION
Scoping the pomerium auth cookie to `security.cdssandbox.xyz` instead of at the route level e.g `neo4j.security.cdssandbox.xyz`. This will allow us to login once for all pomerium protected routes and no longer required to login to the bolt service manually to get around websockets not being able to redirect to authentication pages.

If you have any `_pomerium` cookies in your browser you'll have to delete them otherwise you'll be in a endless loop since two session cookies will be provided. Once you perform a login and obtain this newly scoped cookie, you won't need to clear cookies in the future since only a single cookie will be sent to the pomerium service.