### PR TITLE
fix: add fargate spot capacity provider

### DIFF
--- a/terragrunt/aws/cloud_asset_inventory/ecs.tf
+++ b/terragrunt/aws/cloud_asset_inventory/ecs.tf
@@ -1,6 +1,12 @@
 resource "aws_ecs_cluster" "cloud_asset_discovery" {
   name = "cloud_asset_discovery"
 
+  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE_SPOT"
+  }
+
   setting {
     name  = "containerInsights"
     value = "enabled"


### PR DESCRIPTION
ECS cluster for cloud asset discovery had the default capacity providers which didn't allow the step function to run using `FARGATE_SPOT`

![image](https://user-images.githubusercontent.com/85885638/167044347-09394d45-7c30-47ee-bb1d-6c82c410f7de.png)
