### PR TITLE
feat: retry task when spot instance is terminated

### DIFF
--- a/terragrunt/aws/cloud_asset_inventory/state-machines/cartography.json.tmpl
+++ b/terragrunt/aws/cloud_asset_inventory/state-machines/cartography.json.tmpl
@@ -76,6 +76,13 @@
                 }
               }
             },
+            "Retry": [
+              {
+                "ErrorEquals": ["States.TaskFailed"],
+                "IntervalSeconds": 120,
+                "MaxAttempts": 4
+              }
+            ],
             "End": true
           }
         }
@@ -108,7 +115,14 @@
             "SecurityGroups": ["${SECURITY_GROUPS}"],
             "Subnets": ["${SUBNETS}"]
           }
-        }
+        },
+        "Retry": [
+          {
+            "ErrorEquals": ["States.TaskFailed"],
+            "IntervalSeconds": 120,
+            "MaxAttempts": 4
+          }
+        ]
       },
       "End": true
     }


### PR DESCRIPTION
Fargate spot tasks can be interrupted by Amazon when they want the capacity back for their Fargate workloads. This PR introduces retry mechanism in the event that the task is stopped. With Fargate being the backup capacity provider, the expectation is for the task to start as a Fargate task if Fargate spot is unavailable.