### PR TITLE
fix: retry config typo

### DIFF
--- a/terragrunt/aws/cloud_asset_inventory/state-machines/cartography.json.tmpl
+++ b/terragrunt/aws/cloud_asset_inventory/state-machines/cartography.json.tmpl
@@ -115,15 +115,15 @@
             "SecurityGroups": ["${SECURITY_GROUPS}"],
             "Subnets": ["${SUBNETS}"]
           }
-        },
-        "Retry": [
-          {
-            "ErrorEquals": ["States.TaskFailed"],
-            "IntervalSeconds": 120,
-            "MaxAttempts": 4
-          }
-        ]
+        }
       },
+      "Retry": [
+        {
+          "ErrorEquals": ["States.TaskFailed"],
+          "IntervalSeconds": 120,
+          "MaxAttempts": 4
+        }
+      ],
       "End": true
     }
   }


### PR DESCRIPTION
Accidently put the retry config within the parameter block. Moving it to wear it belongs....