### PR TITLE
fix: disable vpc eip instead ecs will use dynamic ip to get images

### DIFF
--- a/terragrunt/aws/software_asset_inventory/api_server.tf
+++ b/terragrunt/aws/software_asset_inventory/api_server.tf
@@ -17,8 +17,9 @@ resource "aws_ecs_service" "dependencytrack_api" {
   }
 
   network_configuration {
-    security_groups = [aws_security_group.dependencytrack.id, module.dependencytrack_db.proxy_security_group_id]
-    subnets         = module.vpc.private_subnet_ids
+    security_groups  = [aws_security_group.dependencytrack.id, module.dependencytrack_db.proxy_security_group_id]
+    subnets          = module.vpc.private_subnet_ids
+    assign_public_ip = true
   }
 
   tags = {

--- a/terragrunt/aws/software_asset_inventory/frontend.tf
+++ b/terragrunt/aws/software_asset_inventory/frontend.tf
@@ -17,8 +17,9 @@ resource "aws_ecs_service" "dependencytrack_frontend" {
   }
 
   network_configuration {
-    security_groups = [aws_security_group.dependencytrack.id, module.dependencytrack_db.proxy_security_group_id]
-    subnets         = module.vpc.private_subnet_ids
+    security_groups  = [aws_security_group.dependencytrack.id, module.dependencytrack_db.proxy_security_group_id]
+    subnets          = module.vpc.private_subnet_ids
+    assign_public_ip = true
   }
 
   tags = {

--- a/terragrunt/aws/software_asset_inventory/vpc.tf
+++ b/terragrunt/aws/software_asset_inventory/vpc.tf
@@ -10,7 +10,7 @@ module "vpc" {
   enable_flow_log   = false
   block_ssh         = true
   block_rdp         = true
-  enable_eip        = true
+  enable_eip        = false
 
   allow_https_request_out          = true
   allow_https_request_out_response = true


### PR DESCRIPTION
Each AWS account has a limit of 5 EIP it can allocate. I've already exceeded that amount and don't intend to request a quota increase from AWS support. Instead each ECS task will be assigned a dynamic public ips for the purpose of downloading images outside of ECR and to download updates.

The security group only allows access from the private subnet, so these dynamic public ips will not have any inbound ports exposed to the internet