### PR TITLE
fix: bump rds instance class to the smallest allowed

### DIFF
--- a/terragrunt/aws/software_asset_inventory/rds.tf
+++ b/terragrunt/aws/software_asset_inventory/rds.tf
@@ -6,7 +6,7 @@ module "dependencytrack_db" {
   engine         = "aurora-postgresql"
   engine_version = "13.6"
   instances      = 2
-  instance_class = "db.t3.small"
+  instance_class = "db.t3.medium"
   username       = aws_ssm_parameter.dependencytrack_db_user.value
   password       = aws_ssm_parameter.dependencytrack_db_password.value
 


### PR DESCRIPTION
Aurora postgresql minimum instance class is `db.t3.medium`