### PR TITLE
docs: updated readme before archiving and nuking the account

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
-# Security Tools
-La version française sera disponible bientôt
+# Status: Archived
+This repository has been archived and is no longer maintained. This was an experiment using security tools residing in multiple VPC's peered to a central VPC hosting a SSO proxy. The number of NAT gateways was becoming excessive and costly. The CDS security team will no longer be pursueing this architecture in favour of using one VPC as well as exploring EKS.
 
-# Description
+![status: inactive](https://img.shields.io/badge/status-inactive-red.svg)
+
+This work will renamed to security-tools-ecs and be superseded by https://github.com/cds-snc/security-tools
+
+## Security Tools
+
+### Description
 
 This repository will contain various tools used by CDS to ensure the confidentiality, integrity and availability of CDS applications and services.
 
-# Services
+### Services
 
 - SSO Proxy : AWS, ECS, Google SSO, [Pomerium](https://github.com/pomerium/pomerium)
 - Cloud Asset Inventory: AWS, ECS, Lambda [Cartography](https://github.com/lyft/cartography), Neo4j, Elasticsearch
 
-# License
+### License
 
 This code is released under the MIT License. See [LICENSE](LICENSE).


### PR DESCRIPTION
We'll be re-designing the architecture of the platform security tools setup. The current multiple VPC approach has hit a limitation that makes the current design impractical. This repo will be renamed and archived to serve as en example of vpc peering.

We originally planned for a hub/spoke setup with a central VPC peered with a VPC per tool we'll be running. Unfortunately there's a limit to the amount of public NAT gateways you can deploy due to AWS limiting each AWS account to 5 static IP addresses. The number of NAT gateways was also becoming a concern and would have significantly increased the cost of this project.

We'll be looking into collapsing everything into a single VPC and potentially migrating to Amazon Managed Kubernetes (eks) instead of using ECS clusters.

[Link to rendered updated docs](https://github.com/cds-snc/security-tools/blob/4153e45084aa449845d8f6e7e37277aa50989fb0/README.md)